### PR TITLE
Updating script to point to avocados

### DIFF
--- a/JMeter/Plans/Frontstage_R16.jmx
+++ b/JMeter/Plans/Frontstage_R16.jmx
@@ -14,7 +14,7 @@
           </elementProp>
           <elementProp name="host" elementType="Argument">
             <stringProp name="Argument.name">host</stringProp>
-            <stringProp name="Argument.value">ras-frontstage-perf.apps.prunes.cf2.onsclofo.uk</stringProp>
+            <stringProp name="Argument.value">ras-frontstage-perf.apps.avocados.cf2.onsclofo.uk</stringProp>
             <stringProp name="Argument.metadata">=</stringProp>
           </elementProp>
           <elementProp name="think_time" elementType="Argument">
@@ -214,7 +214,7 @@
                 <collectionProp name="HeaderManager.headers">
                   <elementProp name="Referer" elementType="Header">
                     <stringProp name="Header.name">Referer</stringProp>
-                    <stringProp name="Header.value">http://ras-frontstage-perf.apps.prunes.cf2.onsclofo.uk/sign-in/</stringProp>
+                    <stringProp name="Header.value">http://ras-frontstage-perf.apps.avocados.cf2.onsclofo.uk/sign-in/</stringProp>
                   </elementProp>
                   <elementProp name="Accept-Language" elementType="Header">
                     <stringProp name="Header.name">Accept-Language</stringProp>
@@ -260,7 +260,7 @@
                 <collectionProp name="HeaderManager.headers">
                   <elementProp name="Referer" elementType="Header">
                     <stringProp name="Header.name">Referer</stringProp>
-                    <stringProp name="Header.value">http://ras-frontstage-perf.apps.prunes.cf2.onsclofo.uk/sign-in/</stringProp>
+                    <stringProp name="Header.value">http://ras-frontstage-perf.apps.avocados.cf2.onsclofo.uk/sign-in/</stringProp>
                   </elementProp>
                   <elementProp name="Accept-Language" elementType="Header">
                     <stringProp name="Header.name">Accept-Language</stringProp>
@@ -306,7 +306,7 @@
                 <collectionProp name="HeaderManager.headers">
                   <elementProp name="Referer" elementType="Header">
                     <stringProp name="Header.name">Referer</stringProp>
-                    <stringProp name="Header.value">http://ras-frontstage-perf.apps.prunes.cf2.onsclofo.uk/sign-in/</stringProp>
+                    <stringProp name="Header.value">http://ras-frontstage-perf.apps.avocados.cf2.onsclofo.uk/sign-in/</stringProp>
                   </elementProp>
                   <elementProp name="Accept-Language" elementType="Header">
                     <stringProp name="Header.name">Accept-Language</stringProp>
@@ -352,7 +352,7 @@
                 <collectionProp name="HeaderManager.headers">
                   <elementProp name="Referer" elementType="Header">
                     <stringProp name="Header.name">Referer</stringProp>
-                    <stringProp name="Header.value">http://ras-frontstage-perf.apps.prunes.cf2.onsclofo.uk/sign-in/</stringProp>
+                    <stringProp name="Header.value">http://ras-frontstage-perf.apps.avocados.cf2.onsclofo.uk/sign-in/</stringProp>
                   </elementProp>
                   <elementProp name="Accept-Language" elementType="Header">
                     <stringProp name="Header.name">Accept-Language</stringProp>
@@ -398,7 +398,7 @@
                 <collectionProp name="HeaderManager.headers">
                   <elementProp name="Referer" elementType="Header">
                     <stringProp name="Header.name">Referer</stringProp>
-                    <stringProp name="Header.value">http://ras-frontstage-perf.apps.prunes.cf2.onsclofo.uk/sign-in/</stringProp>
+                    <stringProp name="Header.value">http://ras-frontstage-perf.apps.avocados.cf2.onsclofo.uk/sign-in/</stringProp>
                   </elementProp>
                   <elementProp name="Accept-Language" elementType="Header">
                     <stringProp name="Header.name">Accept-Language</stringProp>
@@ -444,7 +444,7 @@
                 <collectionProp name="HeaderManager.headers">
                   <elementProp name="Referer" elementType="Header">
                     <stringProp name="Header.name">Referer</stringProp>
-                    <stringProp name="Header.value">http://ras-frontstage-perf.apps.prunes.cf2.onsclofo.uk/sign-in/</stringProp>
+                    <stringProp name="Header.value">http://ras-frontstage-perf.apps.avocados.cf2.onsclofo.uk/sign-in/</stringProp>
                   </elementProp>
                   <elementProp name="Accept-Language" elementType="Header">
                     <stringProp name="Header.name">Accept-Language</stringProp>
@@ -452,7 +452,7 @@
                   </elementProp>
                   <elementProp name="Origin" elementType="Header">
                     <stringProp name="Header.name">Origin</stringProp>
-                    <stringProp name="Header.value">http://ras-frontstage-perf.apps.prunes.cf2.onsclofo.uk</stringProp>
+                    <stringProp name="Header.value">http://ras-frontstage-perf.apps.avocados.cf2.onsclofo.uk</stringProp>
                   </elementProp>
                   <elementProp name="Accept-Encoding" elementType="Header">
                     <stringProp name="Header.name">Accept-Encoding</stringProp>
@@ -494,7 +494,7 @@
                 <collectionProp name="HeaderManager.headers">
                   <elementProp name="Referer" elementType="Header">
                     <stringProp name="Header.name">Referer</stringProp>
-                    <stringProp name="Header.value">http://ras-frontstage-perf.apps.prunes.cf2.onsclofo.uk/sign-in/</stringProp>
+                    <stringProp name="Header.value">http://ras-frontstage-perf.apps.avocados.cf2.onsclofo.uk/sign-in/</stringProp>
                   </elementProp>
                   <elementProp name="Accept-Language" elementType="Header">
                     <stringProp name="Header.name">Accept-Language</stringProp>
@@ -502,7 +502,7 @@
                   </elementProp>
                   <elementProp name="Origin" elementType="Header">
                     <stringProp name="Header.name">Origin</stringProp>
-                    <stringProp name="Header.value">http://ras-frontstage-perf.apps.prunes.cf2.onsclofo.uk</stringProp>
+                    <stringProp name="Header.value">http://ras-frontstage-perf.apps.avocados.cf2.onsclofo.uk</stringProp>
                   </elementProp>
                   <elementProp name="Accept-Encoding" elementType="Header">
                     <stringProp name="Header.name">Accept-Encoding</stringProp>
@@ -592,7 +592,7 @@
                 <collectionProp name="HeaderManager.headers">
                   <elementProp name="Referer" elementType="Header">
                     <stringProp name="Header.name">Referer</stringProp>
-                    <stringProp name="Header.value">http://ras-frontstage-perf.apps.prunes.cf2.onsclofo.uk/sign-in/</stringProp>
+                    <stringProp name="Header.value">http://ras-frontstage-perf.apps.avocados.cf2.onsclofo.uk/sign-in/</stringProp>
                   </elementProp>
                   <elementProp name="Accept-Language" elementType="Header">
                     <stringProp name="Header.name">Accept-Language</stringProp>
@@ -683,7 +683,7 @@
                 <collectionProp name="HeaderManager.headers">
                   <elementProp name="Referer" elementType="Header">
                     <stringProp name="Header.name">Referer</stringProp>
-                    <stringProp name="Header.value">http://ras-frontstage-perf.apps.prunes.cf2.onsclofo.uk/register/create-account/</stringProp>
+                    <stringProp name="Header.value">http://ras-frontstage-perf.apps.avocados.cf2.onsclofo.uk/register/create-account/</stringProp>
                   </elementProp>
                   <elementProp name="Accept-Language" elementType="Header">
                     <stringProp name="Header.name">Accept-Language</stringProp>
@@ -777,7 +777,7 @@
                 <collectionProp name="HeaderManager.headers">
                   <elementProp name="Referer" elementType="Header">
                     <stringProp name="Header.name">Referer</stringProp>
-                    <stringProp name="Header.value">http://ras-frontstage-perf.apps.prunes.cf2.onsclofo.uk/register/create-account/</stringProp>
+                    <stringProp name="Header.value">http://ras-frontstage-perf.apps.avocados.cf2.onsclofo.uk/register/create-account/</stringProp>
                   </elementProp>
                   <elementProp name="Accept-Language" elementType="Header">
                     <stringProp name="Header.name">Accept-Language</stringProp>
@@ -841,7 +841,7 @@
                 <collectionProp name="HeaderManager.headers">
                   <elementProp name="Referer" elementType="Header">
                     <stringProp name="Header.name">Referer</stringProp>
-                    <stringProp name="Header.value">http://ras-frontstage-perf.apps.prunes.cf2.onsclofo.uk/register/create-account/confirm-organisation-survey?encrypted_enrolment_code=wo9HVZPND1xr0njfNi5X5l8DaJdEE23gZYY8MOHJqJM%3D</stringProp>
+                    <stringProp name="Header.value">http://ras-frontstage-perf.apps.avocados.cf2.onsclofo.uk/register/create-account/confirm-organisation-survey?encrypted_enrolment_code=wo9HVZPND1xr0njfNi5X5l8DaJdEE23gZYY8MOHJqJM%3D</stringProp>
                   </elementProp>
                   <elementProp name="Accept-Language" elementType="Header">
                     <stringProp name="Header.name">Accept-Language</stringProp>
@@ -973,7 +973,7 @@
                 <collectionProp name="HeaderManager.headers">
                   <elementProp name="Referer" elementType="Header">
                     <stringProp name="Header.name">Referer</stringProp>
-                    <stringProp name="Header.value">http://ras-frontstage-perf.apps.prunes.cf2.onsclofo.uk/register/create-account/enter-account-details?encrypted_enrolment_code=wo9HVZPND1xr0njfNi5X5l8DaJdEE23gZYY8MOHJqJM%3D</stringProp>
+                    <stringProp name="Header.value">http://ras-frontstage-perf.apps.avocados.cf2.onsclofo.uk/register/create-account/enter-account-details?encrypted_enrolment_code=wo9HVZPND1xr0njfNi5X5l8DaJdEE23gZYY8MOHJqJM%3D</stringProp>
                   </elementProp>
                   <elementProp name="Accept-Language" elementType="Header">
                     <stringProp name="Header.name">Accept-Language</stringProp>
@@ -1050,7 +1050,7 @@
                 <collectionProp name="HeaderManager.headers">
                   <elementProp name="Referer" elementType="Header">
                     <stringProp name="Header.name">Referer</stringProp>
-                    <stringProp name="Header.value">http://ras-frontstage-perf.apps.prunes.cf2.onsclofo.uk/register/create-account/enter-account-details?encrypted_enrolment_code=wo9HVZPND1xr0njfNi5X5l8DaJdEE23gZYY8MOHJqJM%3D</stringProp>
+                    <stringProp name="Header.value">http://ras-frontstage-perf.apps.avocados.cf2.onsclofo.uk/register/create-account/enter-account-details?encrypted_enrolment_code=wo9HVZPND1xr0njfNi5X5l8DaJdEE23gZYY8MOHJqJM%3D</stringProp>
                   </elementProp>
                   <elementProp name="Accept-Language" elementType="Header">
                     <stringProp name="Header.name">Accept-Language</stringProp>
@@ -6582,7 +6582,7 @@
         <boolProp name="ProxyControlGui.regex_match">false</boolProp>
         <stringProp name="ProxyControlGui.content_type_include"></stringProp>
         <stringProp name="ProxyControlGui.content_type_exclude"></stringProp>
-        <stringProp name="ProxyControlGui.domains">ras-frontstage-perf.apps.prunes.cf2.onsclofo.uk</stringProp>
+        <stringProp name="ProxyControlGui.domains">ras-frontstage-perf.apps.avocados.cf2.onsclofo.uk</stringProp>
       </ProxyControl>
       <hashTree>
         <RecordingController guiclass="RecordController" testclass="RecordingController" testname="Recording Controller" enabled="true"/>
@@ -6591,7 +6591,7 @@
             <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" testname="User Defined Variables" enabled="true">
               <collectionProp name="Arguments.arguments"/>
             </elementProp>
-            <stringProp name="HTTPSampler.domain">ras-frontstage-perf.apps.prunes.cf2.onsclofo.uk</stringProp>
+            <stringProp name="HTTPSampler.domain">ras-frontstage-perf.apps.avocados.cf2.onsclofo.uk</stringProp>
             <stringProp name="HTTPSampler.port"></stringProp>
             <stringProp name="HTTPSampler.connect_timeout"></stringProp>
             <stringProp name="HTTPSampler.response_timeout"></stringProp>


### PR DESCRIPTION
We are now using the avocados environment for any performance testing instead of the prunes environment. In this PR I've changed all the links from pointing to the prunes environment to the avocados one.

Once this has been merged in, I can put the new script onto the azure boxes. Don't really know how you could test this besides making sure that you can access the avocados urls that have replaced the prunes ones