### PR TITLE
Moving the values into the env vars

### DIFF
--- a/_infra/helm/locust/Chart.yaml
+++ b/_infra/helm/locust/Chart.yaml
@@ -14,11 +14,11 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.0.14
+version: 1.0.15
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 1.0.14
+appVersion: 1.0.15
 
 dependencies:
   - name: locust

--- a/_infra/helm/locust/values.yaml
+++ b/_infra/helm/locust/values.yaml
@@ -22,14 +22,15 @@ locust:
       CSRF_ENABLED: true
       requests_file: requests.json
       test_respondent_password: password
-      test_respondents: 15
+      test_respondents: 21
   master:
     replicas: 1
-    LOCUST_USERS: 15
-    LOCUST_SPAWN_RATE: 1
-    LOCUST_RUN_TIME: 10m
-    LOCUST_ONLY_SUMMARY: true
-    LOCUST_CSV: rasrm
+    environment:
+      LOCUST_USERS: 21
+      LOCUST_SPAWN_RATE: 1
+      LOCUST_RUN_TIME: 10m
+      LOCUST_ONLY_SUMMARY: true
+      LOCUST_CSV: rasrm
   worker:
     replicas: 1
     strategy:

--- a/_infra/helm/locust/values.yaml
+++ b/_infra/helm/locust/values.yaml
@@ -23,14 +23,13 @@ locust:
       requests_file: requests.json
       test_respondent_password: password
       test_respondents: 15
-      LOCUST_USERS: 15
-      LOCUST_SPAWN_RATE: 1
-      LOCUST_RUN_TIME: 10m
-      LOCUST_ONLY_SUMMARY: true
-      LOCUST_CSV: rasrm
   master:
     replicas: 1
-
+    LOCUST_USERS: 15
+    LOCUST_SPAWN_RATE: 1
+    LOCUST_RUN_TIME: 10m
+    LOCUST_ONLY_SUMMARY: true
+    LOCUST_CSV: rasrm
   worker:
     replicas: 1
     strategy:

--- a/_infra/helm/locust/values.yaml
+++ b/_infra/helm/locust/values.yaml
@@ -17,21 +17,19 @@ locust:
       survey: http://survey.performance.svc.cluster.local:8080
       security_user_name: admin
       security_user_password: secret
-      test_respondent_password: password
-      test_respondents: 10
       GOOGLE_CLOUD_PROJECT: "ras-rm-performance-20220908"
       GCS_BUCKET_NAME: "ras-rm-performance-20220908-locust"
       CSRF_ENABLED: true
       requests_file: requests.json
-
-  master:
-    replicas: 1
-    environment:
-      LOCUST_USERS: 10
+      test_respondent_password: password
+      test_respondents: 15
+      LOCUST_USERS: 15
       LOCUST_SPAWN_RATE: 1
-      LOCUST_RUN_TIME: 35m
+      LOCUST_RUN_TIME: 10m
       LOCUST_ONLY_SUMMARY: true
       LOCUST_CSV: rasrm
+  master:
+    replicas: 1
 
   worker:
     replicas: 1


### PR DESCRIPTION
# What and why?

Unable to override the locust env vars via the CI/CD Helm deployment so moving them to the environment variables. Reducing the run time and increasing the users too.
