### PR TITLE
RAS-1011 Replace unmaintained actions/create-release and update google-github-actions/setup-gcloud

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -116,15 +116,8 @@ jobs:
         run: |
           gsutil cp $IMAGE-*.tgz gs://$ARTIFACT_BUCKET/$IMAGE/
 
-      - uses: actions/create-release@v1
+      - name: Create Release
         if: github.ref == 'refs/heads/main'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ env.version }}
-          release_name: ${{ env.version }}
-          body: |
-            Automated release
-            ${{ env.version }}
-          draft: false
-          prerelease: false
+        run: gh release create ${{ env.version }} --title ${{ env.version }} --notes ${{ env.version }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           fetch-depth: '0'
           token: ${{ secrets.BOT_TOKEN }}
-      - uses: google-github-actions/setup-gcloud@v0
+      - uses: google-github-actions/setup-gcloud@v2
         with:
           version: '444.0.0'
           service_account_key: ${{ secrets.GCR_KEY }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,10 +23,15 @@ jobs:
         with:
           fetch-depth: '0'
           token: ${{ secrets.BOT_TOKEN }}
-      - uses: google-github-actions/setup-gcloud@v2
+      - name: Authenticate with Google Cloud
+        id: auth
+        uses: google-github-actions/auth@v2
         with:
-          version: '444.0.0'
-          service_account_key: ${{ secrets.GCR_KEY }}
+          credentials_json: ${{ secrets.GCR_KEY }}
+      - name: Setup Google Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+      - run: |
+          gcloud auth configure-docker
       - name: add helm repo
         run: |
           helm repo add deliveryhero https://charts.deliveryhero.io/

--- a/_infra/helm/locust/Chart.yaml
+++ b/_infra/helm/locust/Chart.yaml
@@ -14,11 +14,11 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.0.14
+version: 1.0.15
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 1.0.14
+appVersion: 1.0.15
 
 dependencies:
   - name: locust


### PR DESCRIPTION
# What and why?
Replacing the unmaintained create release action with a github command that does the same and updating the setup-gcloud. Also changing how gcloud auth works in this repo as it has stopped working with the update and is different from all other repos
# How to test?
Check the build
# Jira
https://jira.ons.gov.uk/browse/RAS-1011