### PR TITLE
Update yaml create pr images

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,6 +44,13 @@ jobs:
         run: |
           git fetch --tags
           echo "tag=$(git describe --tags --abbrev=0)" >> $GITHUB_ENV
+      - name: pr docker tag
+        if: github.ref != 'refs/heads/main'
+        id: tag
+        run: |
+          PR=$(echo "$GITHUB_REF" | awk -F / '{print $3}')
+          echo "$PR"
+          echo "pr_number=pr-$PR" >> $GITHUB_ENV
       - name: update versions
         if: github.ref != 'refs/heads/main'
         env:
@@ -113,12 +120,13 @@ jobs:
       - name: Publish dev Chart
         if: github.ref != 'refs/heads/main'
         run: |
-          mv $IMAGE-${{ env.HELM_VERSION }}.tgz $IMAGE-latest.tgz
+          mv $IMAGE-${{ env.HELM_VERSION }}.tgz $IMAGE-${{ env.pr_number }}.tgz
           gsutil cp $IMAGE-*.tgz gs://$ARTIFACT_BUCKET/$IMAGE/
 
       - name: Publish Charts
         if: github.ref == 'refs/heads/main'
         run: |
+          cp $IMAGE-${{ env.HELM_VERSION }}.tgz $IMAGE-latest.tgz
           gsutil cp $IMAGE-*.tgz gs://$ARTIFACT_BUCKET/$IMAGE/
 
       - name: Create Release

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,7 +44,7 @@ jobs:
         run: |
           git fetch --tags
           echo "tag=$(git describe --tags --abbrev=0)" >> $GITHUB_ENV
-      - name: pr docker tag
+      - name: pr tag
         if: github.ref != 'refs/heads/main'
         id: tag
         run: |

--- a/_infra/helm/locust/Chart.yaml
+++ b/_infra/helm/locust/Chart.yaml
@@ -14,11 +14,11 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.0.17
+version: 1.0.18
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 1.0.17
+appVersion: 1.0.18
 
 dependencies:
   - name: locust

--- a/_infra/helm/locust/Chart.yaml
+++ b/_infra/helm/locust/Chart.yaml
@@ -14,11 +14,11 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.0.18
+version: 1.0.19
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 1.0.18
+appVersion: 1.0.19
 
 dependencies:
   - name: locust


### PR DESCRIPTION
# What and why?
Currently it is not possible to reliably work on this repo using concourse/gcp if 2 PRs are in flight. The issue being that as soon as a commit is pushed to a PR locust-latest.tgz is updated, meaning if you have 2 or more PR's being worked on they are fighting over the same image. This approach aligns with the other repos which creates pr related images on pushes, then updates the latest on merge

# How to test?
Check the code and make sure a PR related image has been created on GCP
# Trello
