### PR TITLE
RAS-1206 Extend Locust test to send a secure message

### DIFF
--- a/_infra/helm/locust/Chart.yaml
+++ b/_infra/helm/locust/Chart.yaml
@@ -14,11 +14,11 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.0.19
+version: 1.0.20
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 1.0.19
+appVersion: 1.0.20
 
 dependencies:
   - name: locust

--- a/_infra/helm/locust/locustfiles/requests.json
+++ b/_infra/helm/locust/locustfiles/requests.json
@@ -7,13 +7,49 @@
         },
         {
             "method": "GET",
-            "url": "/surveys/history",
-            "expected_response_text": "<title>Completed surveys | ONS Business Surveys</title>"
+            "harvest_url": {
+                "id": "create-message-link-1",
+                "link_text": "Get help with this survey"
+            },
+            "expected_response_text": "Choose an option",
+            "grouping": "/help"
+        },
+        {
+            "method": "POST",
+            "url": "self",
+            "data": {
+                "option": "help-completing-this-survey"
+            },
+            "expected_response_text": "Help completing the Quarterly Business Survey",
+            "grouping": "/help"
+        },
+        {
+            "method": "POST",
+            "url": "self",
+            "data": {
+                "option": "answer-survey-question"
+            },
+            "expected_response_text": "Send a message",
+            "grouping": "/help"
+        },
+        {
+            "method": "POST",
+            "url": "self",
+            "data": {
+                "body": "test secure message"
+            },
+            "expected_response_text": "Message sent",
+            "grouping": "/send-message"
         },
         {
             "method": "GET",
             "url": "/secure-message/threads",
-            "expected_response_text": "<title>Messages | ONS Business Surveys</title>"
+            "expected_response_text": "test secure message"
+        },
+        {
+            "method": "GET",
+            "url": "/surveys/history",
+            "expected_response_text": "<title>Completed surveys | ONS Business Surveys</title>"
         },
         {
             "method": "GET",
@@ -22,13 +58,13 @@
         },
         {
             "method": "GET",
-            "expected_response_text": "https://eq.surveys.onsdigital.uk/session?token=",
-            "response_status": 302,
             "harvest_url": {
                 "id": "surveyLongName",
-                "link_text": "Quarterly Business Survey",
-                "grouping": "/surveys/access-survey"
-            }
+                "link_text": "Quarterly Business Survey"
+            },
+            "expected_response_text": "session?token=",
+            "response_status": 302,
+            "grouping": "/surveys/access-survey"
         }
     ]
 }


### PR DESCRIPTION
# What and why?
Adds the secure message path to the request file. As each help path is different due to business uuids I have introduced a self attribute to the request file, this will use the url of the last response to make the POST. I have also enabled response checking in POSTs and allowed the following of redirects

# How to test?
The easiest way to test it is through concourse, I have even left the performance branch pointing at this PR you can find a successful run with the update in 24-07-08-06-21 

You can test it locally if you want, but the repo has become cumbersome to do so (well before this PR). This PR from Mark is useful https://github.com/ONSdigital/ras-rm-performance-tests/pull/26 (i.e the exports and the pipfile, bs4 needs to be added to it)
When it comes to vars they are a bit all over the place when used locally

requests_file = '/mnt/locust/' + os.getenv('requests_file') should just be requests_file ='requests.json'

anywhere /mnt/locust/ is used, just delete it

config = json.load(open("/mnt/locust/collection-exercise-config.json")) 

becomes

config = json.load(open("collection-exercise-config.json"))
