### PR TITLE
Update performance test requests following help journey changes

### DIFF
--- a/_infra/helm/locust/Chart.yaml
+++ b/_infra/helm/locust/Chart.yaml
@@ -14,11 +14,11 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.0.23
+version: 1.0.24
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 1.0.23
+appVersion: 1.0.24
 
 dependencies:
   - name: locust

--- a/_infra/helm/locust/locustfiles/locustfile.py
+++ b/_infra/helm/locust/locustfiles/locustfile.py
@@ -543,13 +543,11 @@ class FrontstageTasks(TaskSet, Mixins):
                         logger.error(f"Unable to harvest url {request['harvest']}")
                         self.interrupt()
 
-                if harvest_details["type"] == "id":
-                    # The name 'value' will be used temporarily until the naming convention of name is changed to id in
-                    # Frontstage. Then this should be updated to match
-                    for value in harvest_details["ids"]:
-                        input_name = soup.find("input", attrs={"name": value})
+                if harvest_details["type"] == "name":
+                    for name in harvest_details["names"]:
+                        input_name = soup.find("input", attrs={"name": name})
                         input_value = input_name.attrs.get("value")
-                        harvest_dict[value] = input_value
+                        harvest_dict[name] = input_value
             else:
                 request_url = request["url"]
 

--- a/_infra/helm/locust/locustfiles/requests.json
+++ b/_infra/helm/locust/locustfiles/requests.json
@@ -7,39 +7,18 @@
         },
         {
             "method": "GET",
-            "harvest_url": {
-                "id": "create-message-link-1",
-                "link_text": "Get help with this survey"
-            },
-            "expected_response_text": "Choose an option",
-            "grouping": "/help"
+            "url": "/contact-us/send-message",
+            "expected_response_text": "Send a message"
         },
         {
             "method": "POST",
-            "url": "self",
+            "url": "/contact-us/send-message",
             "data": {
-                "option": "help-completing-this-survey"
-            },
-            "expected_response_text": "Help completing the Quarterly Business Survey",
-            "grouping": "/help"
-        },
-        {
-            "method": "POST",
-            "url": "self",
-            "data": {
-                "option": "answer-survey-question"
-            },
-            "expected_response_text": "Send a message",
-            "grouping": "/help"
-        },
-        {
-            "method": "POST",
-            "url": "self",
-            "data": {
+                "survey_id": "02b9c366-7397-42f7-942a-76dc5876d86d",
+                "subject": "Help with my survey",
                 "body": "test secure message"
             },
-            "expected_response_text": "Message sent",
-            "grouping": "/send-message"
+            "expected_response_text": "Your message has been sent, a request can take up to 5 working days "
         },
         {
             "method": "GET",

--- a/_infra/helm/locust/locustfiles/requests.json
+++ b/_infra/helm/locust/locustfiles/requests.json
@@ -20,8 +20,8 @@
             },
             "expected_response_text": "Click on the survey name to complete your questionnaire.",
             "harvest": {
-                "ids": ["business_id"],
-                "type": "id"
+                "names": ["business_id"],
+                "type": "name"
             }
         },
         {

--- a/_infra/helm/locust/locustfiles/requests.json
+++ b/_infra/helm/locust/locustfiles/requests.json
@@ -18,7 +18,11 @@
                 "subject": "Help with my survey",
                 "body": "test secure message"
             },
-            "expected_response_text": "Your message has been sent, a request can take up to 5 working days "
+            "expected_response_text": "Click on the survey name to complete your questionnaire.",
+            "harvest": {
+                "ids": ["business_id"],
+                "type": "id"
+            }
         },
         {
             "method": "GET",
@@ -37,8 +41,8 @@
         },
         {
             "method": "GET",
-            "harvest_url": {
-                "id": "surveyLongName",
+            "harvest": {
+                "ids": "surveyLongName",
                 "link_text": "Quarterly Business Survey"
             },
             "expected_response_text": "session?token=",

--- a/_infra/helm/locust/locustfiles/requests.json
+++ b/_infra/helm/locust/locustfiles/requests.json
@@ -42,8 +42,9 @@
         {
             "method": "GET",
             "harvest": {
-                "ids": "surveyLongName",
-                "link_text": "Quarterly Business Survey"
+                "id": "surveyLongName",
+                "link_text": "Quarterly Business Survey",
+                "type": "url"
             },
             "expected_response_text": "session?token=",
             "response_status": 302,


### PR DESCRIPTION
# What and why?
The Frontstage user journey work has been completed. In order to allow the performance tests to run correctly against the new implementation of Frontstage, the message posting needed to be updated. This PR achieves this.

# How to test?

1. Build out your env in dev
2. Elevate the 'compute' service account to 'Storage Admin'
3. Then using the helm/fly commands found in the [README.md](https://github.com/ONSdigital/ras-rm-performance-tests/blob/main/README.md), run locust (you can reduce the amount of time and users etc if you want to speed things up) in your dev env
4. Once completed, in the GCP logging, run: `resource.type="k8s_container"
resource.labels.project_id="ras-rm-dev"
resource.labels.location="europe-west2"
resource.labels.cluster_name="k8s-ras"
resource.labels.namespace_name="[YOUR_NAMESPACE]"
labels.k8s-pod/app_kubernetes_io/instance="locust"
labels.k8s-pod/app_kubernetes_io/name="locust"
labels.k8s-pod/component="master"
labels.k8s-pod/load_test="performance-test" severity>=DEFAULT` 
5. Check the logs and the 'GET' and 'POST' entries for endpoint '/help' and endpoint '/send-message' should have failed
6. Once checks are done, run the 'psql' scripts as stated in the [README.md](https://github.com/ONSdigital/ras-rm-performance-tests/blob/main/README.md
7. Pull this PR and then repeat step 2
8. Go back and refresh the logs
9. The lines for '/help' and '/send-message' will have been replaced by '/contact-us/send-message'. These should show as passed

Alternatively:
Run this in performance by changing the locust image from 'latest' to 'locust-pr-40.tgz' in the 'variables.performance.yaml' file and run fly. Just follow the above steps omitting steps 1 and 2.

**Note:** I think I have covered the only scenario required. But if you believe I should add any more, then let me know.

# Jira
https://jira.ons.gov.uk/browse/RAS-1531