### PR TITLE
RAS-1836 Fix locust permissions introduced with WIF

### DIFF
--- a/_infra/helm/locust/Chart.yaml
+++ b/_infra/helm/locust/Chart.yaml
@@ -14,11 +14,11 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.0.27
+version: 1.0.28
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 1.0.27
+appVersion: 1.0.28
 
 dependencies:
   - name: locust

--- a/_infra/helm/locust/locustfiles/locustfile.py
+++ b/_infra/helm/locust/locustfiles/locustfile.py
@@ -460,17 +460,24 @@ def on_test_start(environment, **kwargs):
 def on_test_stop(environment, **kwargs):
     logger.info("on_test_stop Locust runner: %s", environment.runner)
     if isinstance(environment.runner, (MasterRunner, LocalRunner)):
+        logger.info("initialising bucket connection")
         gcs = GoogleCloudStorage()
+        logger.info("initialised bucket")
         failures = "rasrm_failures.csv"
         stats = "rasrm_stats.csv"
         history = "rasrm_stats_history.csv"
 
+        logger.info("about to upload files")
         with open(failures) as f:
+            logger.info("uploading failure file")
             gcs.upload(file_name=failures, file=f.read())
         with open(stats) as s:
+            logger.info("uploading stats file")
             gcs.upload(file_name=stats, file=s.read())
         with open(history) as h:
+            logger.info("uploading history file")
             gcs.upload(file_name=history, file=h.read())
+        logger.info("Successfully uploaded files")
 
 
 class Mixins:
@@ -614,13 +621,20 @@ class GoogleCloudStorage:
     def __init__(self):
         self.project_id = os.getenv("GOOGLE_CLOUD_PROJECT")
         self.bucket_name = os.getenv("GCS_BUCKET_NAME")
+        logger.info("Creating Google Cloud Storage")
         self.client = storage.Client(project=self.project_id)
+        logger.info("setting up bucket")
         self.bucket = self.client.bucket(self.bucket_name)
+        logger.info(f"bucket: {self.bucket}")
 
     def upload(self, file_name, file):
+        logger.info(f"Uploading {file_name} to Google Cloud Storage")
         path = datetime.utcnow().strftime("%y-%m-%d-%H-%M") + "/" + file_name
+        logger.info("created file path")
         blob = self.bucket.blob(path)
+        logger.info("created blob and about to upload")
         blob.upload_from_string(data=file, content_type="application/csv")
+        logger.info(f"Uploaded {file_name} to Google Cloud Storage")
 
 
 def _capture_csrf_token(html):

--- a/_infra/helm/locust/locustfiles/locustfile.py
+++ b/_infra/helm/locust/locustfiles/locustfile.py
@@ -61,7 +61,6 @@ SURVEY_DETAILS = [
     },
 ]
 
-
 # Load data for tests
 def load_data():
     logger.info(f"Container host: {socket.gethostname()}")
@@ -472,7 +471,6 @@ def on_test_stop(environment, **kwargs):
             gcs.upload(file_name=stats, file=s.read())
         with open(history) as h:
             gcs.upload(file_name=history, file=h.read())
-        logger.info("Successfully uploaded files")
 
 
 class Mixins:

--- a/_infra/helm/locust/locustfiles/locustfile.py
+++ b/_infra/helm/locust/locustfiles/locustfile.py
@@ -18,6 +18,9 @@ from google.cloud import storage
 from locust import HttpUser, TaskSet, task, events
 from locust.runners import MasterRunner, LocalRunner
 
+from gevent import spawn, sleep
+
+
 
 logging.basicConfig(level=logging.DEBUG, format="%(message)s")
 logger = logging.getLogger()
@@ -63,6 +66,8 @@ SURVEY_DETAILS = [
 
 client = storage.Client()
 logger.info(f"client: {client}")
+
+upload_complete = False
 
 
 # Load data for tests
@@ -457,6 +462,7 @@ def data_loaded():
 def on_test_start(environment, **kwargs):
     logger.info("on_test_start Locust runner: %s", environment.runner)
     if isinstance(environment.runner, (MasterRunner, LocalRunner)):
+        environment.runner.upload_greenlet = spawn(lambda: None)
         load_data()
 
 
@@ -464,24 +470,11 @@ def on_test_start(environment, **kwargs):
 def on_test_stop(environment, **kwargs):
     logger.info("on_test_stop Locust runner: %s", environment.runner)
     if isinstance(environment.runner, (MasterRunner, LocalRunner)):
-        logger.info("initialising bucket connection")
-        gcs = GoogleCloudStorage()
-        logger.info("initialised bucket")
-        failures = "rasrm_failures.csv"
-        stats = "rasrm_stats.csv"
-        history = "rasrm_stats_history.csv"
+        environment.runner.upload_greenlet.kill()
+        environment.runner.upload_greenlet = spawn(_upload_files)
 
-        logger.info("about to upload files")
-        with open(failures) as f:
-            logger.info("uploading failure file")
-            gcs.upload(file_name=failures, file=f.read())
-        with open(stats) as s:
-            logger.info("uploading stats file")
-            gcs.upload(file_name=stats, file=s.read())
-        with open(history) as h:
-            logger.info("uploading history file")
-            gcs.upload(file_name=history, file=h.read())
-        logger.info("Successfully uploaded files")
+        while not upload_complete:
+            sleep(0.1)
 
 
 class Mixins:
@@ -651,3 +644,27 @@ def _capture_csrf_token(html):
 def _generate_random_respondent():
     respondent_email = f"499{random.randint(0, RESPONDENTS-1):08}@test.com"
     return {"username": respondent_email, "password": os.getenv("test_respondent_password")}
+
+
+def _upload_files():
+    global upload_complete
+    logger.info("initialising bucket connection")
+    gcs = GoogleCloudStorage()
+    logger.info("initialised bucket")
+    failures = "rasrm_failures.csv"
+    stats = "rasrm_stats.csv"
+    history = "rasrm_stats_history.csv"
+
+    logger.info("about to upload files")
+    with open(failures) as f:
+        logger.info("uploading failure file")
+        gcs.upload(file_name=failures, file=f.read())
+    with open(stats) as s:
+        logger.info("uploading stats file")
+        gcs.upload(file_name=stats, file=s.read())
+    with open(history) as h:
+        logger.info("uploading history file")
+        gcs.upload(file_name=history, file=h.read())
+    logger.info("Successfully uploaded files")
+
+    upload_complete = True

--- a/_infra/helm/locust/locustfiles/locustfile.py
+++ b/_infra/helm/locust/locustfiles/locustfile.py
@@ -460,6 +460,7 @@ def on_test_start(environment, **kwargs):
 def on_test_stop(environment, **kwargs):
     logger.info("on_test_stop Locust runner: %s", environment.runner)
     if isinstance(environment.runner, (MasterRunner, LocalRunner)):
+        logger.info("about to upload files")
         gcs = GoogleCloudStorage()
         failures = "rasrm_failures.csv"
         stats = "rasrm_stats.csv"
@@ -471,6 +472,7 @@ def on_test_stop(environment, **kwargs):
             gcs.upload(file_name=stats, file=s.read())
         with open(history) as h:
             gcs.upload(file_name=history, file=h.read())
+        logger.info("Successfully uploaded files")
 
 
 class Mixins:
@@ -621,6 +623,7 @@ class GoogleCloudStorage:
         path = datetime.utcnow().strftime("%y-%m-%d-%H-%M") + "/" + file_name
         blob = self.bucket.blob(path)
         blob.upload_from_string(data=file, content_type="application/csv")
+        logger.info(f"Uploaded {file_name} to Google Cloud Storage")
 
 
 def _capture_csrf_token(html):

--- a/_infra/helm/locust/locustfiles/locustfile.py
+++ b/_infra/helm/locust/locustfiles/locustfile.py
@@ -64,11 +64,6 @@ SURVEY_DETAILS = [
     },
 ]
 
-# client = storage.Client()
-# logger.info(f"client: {client}")
-#
-# upload_complete = False
-
 
 # Load data for tests
 def load_data():
@@ -470,30 +465,17 @@ def on_test_start(environment, **kwargs):
 def on_test_stop(environment, **kwargs):
     logger.info("on_test_stop Locust runner: %s", environment.runner)
     if isinstance(environment.runner, (MasterRunner, LocalRunner)):
-        logger.info("initialising bucket connection")
         gcs = GoogleCloudStorage()
-        logger.info("initialised bucket")
         failures = "rasrm_failures.csv"
         stats = "rasrm_stats.csv"
         history = "rasrm_stats_history.csv"
 
-        logger.info("about to upload files")
         with open(failures) as f:
-            logger.info("uploading failure file")
             gcs.upload(file_name=failures, file=f.read())
         with open(stats) as s:
-            logger.info("uploading stats file")
             gcs.upload(file_name=stats, file=s.read())
         with open(history) as h:
-            logger.info("uploading history file")
             gcs.upload(file_name=history, file=h.read())
-        logger.info("Successfully uploaded files")
-
-        # environment.runner.upload_greenlet.kill()
-        # environment.runner.upload_greenlet = spawn(_upload_files)
-        #
-        # while not upload_complete:
-        #     sleep(0.1)
 
 
 class Mixins:
@@ -637,21 +619,13 @@ class GoogleCloudStorage:
     def __init__(self):
         self.project_id = os.getenv("GOOGLE_CLOUD_PROJECT")
         self.bucket_name = os.getenv("GCS_BUCKET_NAME")
-        logger.info("Creating Google Cloud Storage")
         self.client = storage.Client(project=self.project_id)
-        # logger.info(f"client: {client}")
-        logger.info("setting up bucket")
         self.bucket = self.client.bucket(self.bucket_name)
-        logger.info(f"bucket: {self.bucket}")
 
     def upload(self, file_name, file):
-        logger.info(f"Uploading {file_name} to Google Cloud Storage")
         path = datetime.utcnow().strftime("%y-%m-%d-%H-%M") + "/" + file_name
-        logger.info("created file path")
         blob = self.bucket.blob(path)
-        logger.info("created blob and about to upload")
         blob.upload_from_string(data=file, content_type="application/csv")
-        logger.info(f"Uploaded {file_name} to Google Cloud Storage")
 
 
 def _capture_csrf_token(html):
@@ -663,27 +637,3 @@ def _capture_csrf_token(html):
 def _generate_random_respondent():
     respondent_email = f"499{random.randint(0, RESPONDENTS-1):08}@test.com"
     return {"username": respondent_email, "password": os.getenv("test_respondent_password")}
-
-
-# def _upload_files():
-#     global upload_complete
-#     logger.info("initialising bucket connection")
-#     gcs = GoogleCloudStorage()
-#     logger.info("initialised bucket")
-#     failures = "rasrm_failures.csv"
-#     stats = "rasrm_stats.csv"
-#     history = "rasrm_stats_history.csv"
-#
-#     logger.info("about to upload files")
-#     with open(failures) as f:
-#         logger.info("uploading failure file")
-#         gcs.upload(file_name=failures, file=f.read())
-#     with open(stats) as s:
-#         logger.info("uploading stats file")
-#         gcs.upload(file_name=stats, file=s.read())
-#     with open(history) as h:
-#         logger.info("uploading history file")
-#         gcs.upload(file_name=history, file=h.read())
-#     logger.info("Successfully uploaded files")
-#
-#     upload_complete = True

--- a/_infra/helm/locust/locustfiles/locustfile.py
+++ b/_infra/helm/locust/locustfiles/locustfile.py
@@ -627,7 +627,8 @@ class GoogleCloudStorage:
         self.bucket_name = os.getenv("GCS_BUCKET_NAME")
         logger.info("Creating Google Cloud Storage")
         # self.client = storage.Client(project=self.project_id)
-        logger.info(f"client: {client}")
+        # logger.info(f"client: {client}")
+        logger.info("setting up bucket")
         self.bucket = client.bucket(self.bucket_name)
         logger.info(f"bucket: {self.bucket}")
 

--- a/_infra/helm/locust/locustfiles/locustfile.py
+++ b/_infra/helm/locust/locustfiles/locustfile.py
@@ -64,10 +64,10 @@ SURVEY_DETAILS = [
     },
 ]
 
-client = storage.Client()
-logger.info(f"client: {client}")
-
-upload_complete = False
+# client = storage.Client()
+# logger.info(f"client: {client}")
+#
+# upload_complete = False
 
 
 # Load data for tests
@@ -470,11 +470,30 @@ def on_test_start(environment, **kwargs):
 def on_test_stop(environment, **kwargs):
     logger.info("on_test_stop Locust runner: %s", environment.runner)
     if isinstance(environment.runner, (MasterRunner, LocalRunner)):
-        environment.runner.upload_greenlet.kill()
-        environment.runner.upload_greenlet = spawn(_upload_files)
+        logger.info("initialising bucket connection")
+        gcs = GoogleCloudStorage()
+        logger.info("initialised bucket")
+        failures = "rasrm_failures.csv"
+        stats = "rasrm_stats.csv"
+        history = "rasrm_stats_history.csv"
 
-        while not upload_complete:
-            sleep(0.1)
+        logger.info("about to upload files")
+        with open(failures) as f:
+            logger.info("uploading failure file")
+            gcs.upload(file_name=failures, file=f.read())
+        with open(stats) as s:
+            logger.info("uploading stats file")
+            gcs.upload(file_name=stats, file=s.read())
+        with open(history) as h:
+            logger.info("uploading history file")
+            gcs.upload(file_name=history, file=h.read())
+        logger.info("Successfully uploaded files")
+
+        # environment.runner.upload_greenlet.kill()
+        # environment.runner.upload_greenlet = spawn(_upload_files)
+        #
+        # while not upload_complete:
+        #     sleep(0.1)
 
 
 class Mixins:
@@ -619,10 +638,10 @@ class GoogleCloudStorage:
         self.project_id = os.getenv("GOOGLE_CLOUD_PROJECT")
         self.bucket_name = os.getenv("GCS_BUCKET_NAME")
         logger.info("Creating Google Cloud Storage")
-        # self.client = storage.Client(project=self.project_id)
+        self.client = storage.Client(project=self.project_id)
         # logger.info(f"client: {client}")
         logger.info("setting up bucket")
-        self.bucket = client.bucket(self.bucket_name)
+        self.bucket = self.client.bucket(self.bucket_name)
         logger.info(f"bucket: {self.bucket}")
 
     def upload(self, file_name, file):
@@ -646,25 +665,25 @@ def _generate_random_respondent():
     return {"username": respondent_email, "password": os.getenv("test_respondent_password")}
 
 
-def _upload_files():
-    global upload_complete
-    logger.info("initialising bucket connection")
-    gcs = GoogleCloudStorage()
-    logger.info("initialised bucket")
-    failures = "rasrm_failures.csv"
-    stats = "rasrm_stats.csv"
-    history = "rasrm_stats_history.csv"
-
-    logger.info("about to upload files")
-    with open(failures) as f:
-        logger.info("uploading failure file")
-        gcs.upload(file_name=failures, file=f.read())
-    with open(stats) as s:
-        logger.info("uploading stats file")
-        gcs.upload(file_name=stats, file=s.read())
-    with open(history) as h:
-        logger.info("uploading history file")
-        gcs.upload(file_name=history, file=h.read())
-    logger.info("Successfully uploaded files")
-
-    upload_complete = True
+# def _upload_files():
+#     global upload_complete
+#     logger.info("initialising bucket connection")
+#     gcs = GoogleCloudStorage()
+#     logger.info("initialised bucket")
+#     failures = "rasrm_failures.csv"
+#     stats = "rasrm_stats.csv"
+#     history = "rasrm_stats_history.csv"
+#
+#     logger.info("about to upload files")
+#     with open(failures) as f:
+#         logger.info("uploading failure file")
+#         gcs.upload(file_name=failures, file=f.read())
+#     with open(stats) as s:
+#         logger.info("uploading stats file")
+#         gcs.upload(file_name=stats, file=s.read())
+#     with open(history) as h:
+#         logger.info("uploading history file")
+#         gcs.upload(file_name=history, file=h.read())
+#     logger.info("Successfully uploaded files")
+#
+#     upload_complete = True

--- a/_infra/helm/locust/locustfiles/locustfile.py
+++ b/_infra/helm/locust/locustfiles/locustfile.py
@@ -621,8 +621,11 @@ class GoogleCloudStorage:
     def __init__(self):
         self.project_id = os.getenv("GOOGLE_CLOUD_PROJECT")
         self.bucket_name = os.getenv("GCS_BUCKET_NAME")
+        logger.info("Creating Google Cloud Storage")
         self.client = storage.Client(project=self.project_id)
+        logger.info(f"client: {self.client}")
         self.bucket = self.client.bucket(self.bucket_name)
+        logger.info(f"bucket: {self.bucket}")
 
     def upload(self, file_name, file):
         path = datetime.utcnow().strftime("%y-%m-%d-%H-%M") + "/" + file_name

--- a/_infra/helm/locust/locustfiles/locustfile.py
+++ b/_infra/helm/locust/locustfiles/locustfile.py
@@ -460,24 +460,18 @@ def on_test_start(environment, **kwargs):
 def on_test_stop(environment, **kwargs):
     logger.info("on_test_stop Locust runner: %s", environment.runner)
     if isinstance(environment.runner, (MasterRunner, LocalRunner)):
-        logger.info("initialising bucket connection")
         gcs = GoogleCloudStorage()
-        logger.info("initialised bucket")
         failures = "rasrm_failures.csv"
         stats = "rasrm_stats.csv"
         history = "rasrm_stats_history.csv"
 
-        logger.info("about to upload files")
         with open(failures) as f:
-            logger.info("uploading failure file")
             gcs.upload(file_name=failures, file=f.read())
         with open(stats) as s:
-            logger.info("uploading stats file")
             gcs.upload(file_name=stats, file=s.read())
         with open(history) as h:
-            logger.info("uploading history file")
             gcs.upload(file_name=history, file=h.read())
-        logger.info("Successfully uploaded files")
+        time.sleep(60)
 
 
 class Mixins:
@@ -621,20 +615,13 @@ class GoogleCloudStorage:
     def __init__(self):
         self.project_id = os.getenv("GOOGLE_CLOUD_PROJECT")
         self.bucket_name = os.getenv("GCS_BUCKET_NAME")
-        logger.info("Creating Google Cloud Storage")
         self.client = storage.Client(project=self.project_id)
-        logger.info("setting up bucket")
         self.bucket = self.client.bucket(self.bucket_name)
-        logger.info(f"bucket: {self.bucket}")
 
     def upload(self, file_name, file):
-        logger.info(f"Uploading {file_name} to Google Cloud Storage")
         path = datetime.utcnow().strftime("%y-%m-%d-%H-%M") + "/" + file_name
-        logger.info("created file path")
         blob = self.bucket.blob(path)
-        logger.info("created blob and about to upload")
         blob.upload_from_string(data=file, content_type="application/csv")
-        logger.info(f"Uploaded {file_name} to Google Cloud Storage")
 
 
 def _capture_csrf_token(html):

--- a/_infra/helm/locust/locustfiles/locustfile.py
+++ b/_infra/helm/locust/locustfiles/locustfile.py
@@ -633,8 +633,11 @@ class GoogleCloudStorage:
         logger.info(f"bucket: {self.bucket}")
 
     def upload(self, file_name, file):
+        logger.info(f"Uploading {file_name} to Google Cloud Storage")
         path = datetime.utcnow().strftime("%y-%m-%d-%H-%M") + "/" + file_name
+        logger.info("created file path")
         blob = self.bucket.blob(path)
+        logger.info("created blob and about to upload")
         blob.upload_from_string(data=file, content_type="application/csv")
         logger.info(f"Uploaded {file_name} to Google Cloud Storage")
 

--- a/_infra/helm/locust/locustfiles/locustfile.py
+++ b/_infra/helm/locust/locustfiles/locustfile.py
@@ -460,17 +460,22 @@ def on_test_start(environment, **kwargs):
 def on_test_stop(environment, **kwargs):
     logger.info("on_test_stop Locust runner: %s", environment.runner)
     if isinstance(environment.runner, (MasterRunner, LocalRunner)):
-        logger.info("about to upload files")
+        logger.info("initialising bucket connection")
         gcs = GoogleCloudStorage()
+        logger.info("initialised bucket")
         failures = "rasrm_failures.csv"
         stats = "rasrm_stats.csv"
         history = "rasrm_stats_history.csv"
 
+        logger.info("about to upload files")
         with open(failures) as f:
+            logger.info("uploading failure file")
             gcs.upload(file_name=failures, file=f.read())
         with open(stats) as s:
+            logger.info("uploading stats file")
             gcs.upload(file_name=stats, file=s.read())
         with open(history) as h:
+            logger.info("uploading history file")
             gcs.upload(file_name=history, file=h.read())
         logger.info("Successfully uploaded files")
 

--- a/_infra/helm/locust/locustfiles/locustfile.py
+++ b/_infra/helm/locust/locustfiles/locustfile.py
@@ -465,17 +465,24 @@ def on_test_start(environment, **kwargs):
 def on_test_stop(environment, **kwargs):
     logger.info("on_test_stop Locust runner: %s", environment.runner)
     if isinstance(environment.runner, (MasterRunner, LocalRunner)):
+        logger.info("initialising bucket connection")
         gcs = GoogleCloudStorage()
+        logger.info("initialised bucket")
         failures = "rasrm_failures.csv"
         stats = "rasrm_stats.csv"
         history = "rasrm_stats_history.csv"
 
+        logger.info("about to upload files")
         with open(failures) as f:
+            logger.info("uploading failure file")
             gcs.upload(file_name=failures, file=f.read())
         with open(stats) as s:
+            logger.info("uploading stats file")
             gcs.upload(file_name=stats, file=s.read())
         with open(history) as h:
+            logger.info("uploading history file")
             gcs.upload(file_name=history, file=h.read())
+        logger.info("Successfully uploaded files")
 
 
 class Mixins:
@@ -619,13 +626,20 @@ class GoogleCloudStorage:
     def __init__(self):
         self.project_id = os.getenv("GOOGLE_CLOUD_PROJECT")
         self.bucket_name = os.getenv("GCS_BUCKET_NAME")
+        logger.info("Creating Google Cloud Storage")
         self.client = storage.Client(project=self.project_id)
+        logger.info("setting up bucket")
         self.bucket = self.client.bucket(self.bucket_name)
+        logger.info(f"bucket: {self.bucket}")
 
     def upload(self, file_name, file):
+        logger.info(f"Uploading {file_name} to Google Cloud Storage")
         path = datetime.utcnow().strftime("%y-%m-%d-%H-%M") + "/" + file_name
+        logger.info("created file path")
         blob = self.bucket.blob(path)
+        logger.info("created blob and about to upload")
         blob.upload_from_string(data=file, content_type="application/csv")
+        logger.info(f"Uploaded {file_name} to Google Cloud Storage")
 
 
 def _capture_csrf_token(html):

--- a/_infra/helm/locust/locustfiles/locustfile.py
+++ b/_infra/helm/locust/locustfiles/locustfile.py
@@ -18,9 +18,6 @@ from google.cloud import storage
 from locust import HttpUser, TaskSet, task, events
 from locust.runners import MasterRunner, LocalRunner
 
-from gevent import spawn, sleep
-
-
 
 logging.basicConfig(level=logging.DEBUG, format="%(message)s")
 logger = logging.getLogger()
@@ -457,7 +454,6 @@ def data_loaded():
 def on_test_start(environment, **kwargs):
     logger.info("on_test_start Locust runner: %s", environment.runner)
     if isinstance(environment.runner, (MasterRunner, LocalRunner)):
-        environment.runner.upload_greenlet = spawn(lambda: None)
         load_data()
 
 
@@ -465,22 +461,16 @@ def on_test_start(environment, **kwargs):
 def on_test_stop(environment, **kwargs):
     logger.info("on_test_stop Locust runner: %s", environment.runner)
     if isinstance(environment.runner, (MasterRunner, LocalRunner)):
-        logger.info("initialising bucket connection")
         gcs = GoogleCloudStorage()
-        logger.info("initialised bucket")
         failures = "rasrm_failures.csv"
         stats = "rasrm_stats.csv"
         history = "rasrm_stats_history.csv"
 
-        logger.info("about to upload files")
         with open(failures) as f:
-            logger.info("uploading failure file")
             gcs.upload(file_name=failures, file=f.read())
         with open(stats) as s:
-            logger.info("uploading stats file")
             gcs.upload(file_name=stats, file=s.read())
         with open(history) as h:
-            logger.info("uploading history file")
             gcs.upload(file_name=history, file=h.read())
         logger.info("Successfully uploaded files")
 
@@ -626,20 +616,13 @@ class GoogleCloudStorage:
     def __init__(self):
         self.project_id = os.getenv("GOOGLE_CLOUD_PROJECT")
         self.bucket_name = os.getenv("GCS_BUCKET_NAME")
-        logger.info("Creating Google Cloud Storage")
         self.client = storage.Client(project=self.project_id)
-        logger.info("setting up bucket")
         self.bucket = self.client.bucket(self.bucket_name)
-        logger.info(f"bucket: {self.bucket}")
 
     def upload(self, file_name, file):
-        logger.info(f"Uploading {file_name} to Google Cloud Storage")
         path = datetime.utcnow().strftime("%y-%m-%d-%H-%M") + "/" + file_name
-        logger.info("created file path")
         blob = self.bucket.blob(path)
-        logger.info("created blob and about to upload")
         blob.upload_from_string(data=file, content_type="application/csv")
-        logger.info(f"Uploaded {file_name} to Google Cloud Storage")
 
 
 def _capture_csrf_token(html):

--- a/_infra/helm/locust/locustfiles/locustfile.py
+++ b/_infra/helm/locust/locustfiles/locustfile.py
@@ -61,6 +61,10 @@ SURVEY_DETAILS = [
     },
 ]
 
+client = storage.Client()
+logger.info(f"client: {client}")
+
+
 # Load data for tests
 def load_data():
     logger.info(f"Container host: {socket.gethostname()}")
@@ -622,9 +626,9 @@ class GoogleCloudStorage:
         self.project_id = os.getenv("GOOGLE_CLOUD_PROJECT")
         self.bucket_name = os.getenv("GCS_BUCKET_NAME")
         logger.info("Creating Google Cloud Storage")
-        self.client = storage.Client(project=self.project_id)
-        logger.info(f"client: {self.client}")
-        self.bucket = self.client.bucket(self.bucket_name)
+        # self.client = storage.Client(project=self.project_id)
+        logger.info(f"client: {client}")
+        self.bucket = client.bucket(self.bucket_name)
         logger.info(f"bucket: {self.bucket}")
 
     def upload(self, file_name, file):

--- a/_infra/helm/locust/values.yaml
+++ b/_infra/helm/locust/values.yaml
@@ -35,8 +35,6 @@ locust:
       LOCUST_RUN_TIME: 15m
       LOCUST_ONLY_SUMMARY: true
       LOCUST_CSV: rasrm
-    serviceAccountAnnotations:
-      iam.gke.io/gcp-service-account: ras-rm-k8s-services@ras-rm-performance-20220908.iam.gserviceaccount.com
     nodeSelector:
       iam.gke.io/gke-metadata-server-enabled: "true"
 
@@ -44,8 +42,6 @@ locust:
     replicas: 1
     strategy:
       type: RollingUpdate
-    serviceAccountAnnotations:
-      iam.gke.io/gcp-service-account: ras-rm-k8s-services@ras-rm-performance-20220908.iam.gserviceaccount.com
     nodeSelector:
       iam.gke.io/gke-metadata-server-enabled: "true"
 

--- a/_infra/helm/locust/values.yaml
+++ b/_infra/helm/locust/values.yaml
@@ -8,7 +8,6 @@ locust:
     pip_packages:
       - google-cloud-storage
       - bs4
-      - gevent
     environment:
       case: http://case.performance.svc.cluster.local:8080
       collection_exercise: http://collection-exercise.performance.svc.cluster.local:8080

--- a/_infra/helm/locust/values.yaml
+++ b/_infra/helm/locust/values.yaml
@@ -26,6 +26,7 @@ locust:
       requests_file: requests.json
       user_wait_time_min_seconds: 5
       user_wait_time_max_seconds: 15
+      GOOGLE_CLOUD_LOGGING_VERBOSE: "debug"
 
   master:
     replicas: 1
@@ -35,6 +36,7 @@ locust:
       LOCUST_RUN_TIME: 35m
       LOCUST_ONLY_SUMMARY: true
       LOCUST_CSV: rasrm
+      GOOGLE_CLOUD_LOGGING_VERBOSE: "debug"
     serviceAccountAnnotations:
       iam.gke.io/gcp-service-account: locust-master@ras-rm-performance-20220908.iam.gserviceaccount.com
     nodeSelector:

--- a/_infra/helm/locust/values.yaml
+++ b/_infra/helm/locust/values.yaml
@@ -8,6 +8,7 @@ locust:
     pip_packages:
       - google-cloud-storage
       - bs4
+      - gevent
     environment:
       case: http://case.performance.svc.cluster.local:8080
       collection_exercise: http://collection-exercise.performance.svc.cluster.local:8080
@@ -26,7 +27,6 @@ locust:
       requests_file: requests.json
       user_wait_time_min_seconds: 5
       user_wait_time_max_seconds: 15
-      GOOGLE_CLOUD_LOGGING_VERBOSE: "debug"
 
   master:
     replicas: 1
@@ -36,7 +36,6 @@ locust:
       LOCUST_RUN_TIME: 35m
       LOCUST_ONLY_SUMMARY: true
       LOCUST_CSV: rasrm
-      GOOGLE_CLOUD_LOGGING_VERBOSE: "debug"
     serviceAccountAnnotations:
       iam.gke.io/gcp-service-account: locust-master@ras-rm-performance-20220908.iam.gserviceaccount.com
     nodeSelector:

--- a/_infra/helm/locust/values.yaml
+++ b/_infra/helm/locust/values.yaml
@@ -32,7 +32,8 @@ locust:
     environment:
       LOCUST_USERS: 10
       LOCUST_SPAWN_RATE: 1
-      LOCUST_RUN_TIME: 35m
+      LOCUST_RUN_TIME: 15m
+#      LOCUST_RUN_TIME: 35m
       LOCUST_ONLY_SUMMARY: true
       LOCUST_CSV: rasrm
     serviceAccountAnnotations:

--- a/_infra/helm/locust/values.yaml
+++ b/_infra/helm/locust/values.yaml
@@ -33,8 +33,8 @@ locust:
     environment:
       LOCUST_USERS: 10
       LOCUST_SPAWN_RATE: 1
-      LOCUST_RUN_TIME: 10m
-#      LOCUST_RUN_TIME: 35m
+#      LOCUST_RUN_TIME: 10m
+      LOCUST_RUN_TIME: 35m
       LOCUST_ONLY_SUMMARY: true
       LOCUST_CSV: rasrm
     serviceAccountAnnotations:

--- a/_infra/helm/locust/values.yaml
+++ b/_infra/helm/locust/values.yaml
@@ -33,7 +33,6 @@ locust:
       LOCUST_USERS: 10
       LOCUST_SPAWN_RATE: 1
       LOCUST_RUN_TIME: 15m
-#      LOCUST_RUN_TIME: 35m
       LOCUST_ONLY_SUMMARY: true
       LOCUST_CSV: rasrm
     serviceAccountAnnotations:

--- a/_infra/helm/locust/values.yaml
+++ b/_infra/helm/locust/values.yaml
@@ -37,6 +37,8 @@ locust:
       LOCUST_CSV: rasrm
     serviceAccountAnnotations:
       iam.gke.io/gcp-service-account: locust-master@ras-rm-performance-20220908.iam.gserviceaccount.com
+    nodeSelector:
+      iam.gke.io/gke-metadata-server-enabled: "true"
 
   worker:
     replicas: 1
@@ -44,6 +46,8 @@ locust:
       type: RollingUpdate
     serviceAccountAnnotations:
       iam.gke.io/gcp-service-account: locust-worker@ras-rm-performance-20220908.iam.gserviceaccount.com
+    nodeSelector:
+      iam.gke.io/gke-metadata-server-enabled: "true"
 
   image:
     repository: locustio/locust

--- a/_infra/helm/locust/values.yaml
+++ b/_infra/helm/locust/values.yaml
@@ -35,11 +35,15 @@ locust:
       LOCUST_RUN_TIME: 35m
       LOCUST_ONLY_SUMMARY: true
       LOCUST_CSV: rasrm
+    serviceAccountAnnotations:
+      iam.gke.io/gcp-service-account: locust-master@ras-rm-performance-20220908.iam.gserviceaccount.com
 
   worker:
     replicas: 1
     strategy:
       type: RollingUpdate
+    serviceAccountAnnotations:
+      iam.gke.io/gcp-service-account: locust-worker@ras-rm-performance-20220908.iam.gserviceaccount.com
 
   image:
     repository: locustio/locust

--- a/_infra/helm/locust/values.yaml
+++ b/_infra/helm/locust/values.yaml
@@ -34,10 +34,11 @@ locust:
       LOCUST_USERS: 10
       LOCUST_SPAWN_RATE: 1
       LOCUST_RUN_TIME: 10m
+#      LOCUST_RUN_TIME: 35m
       LOCUST_ONLY_SUMMARY: true
       LOCUST_CSV: rasrm
     serviceAccountAnnotations:
-      iam.gke.io/gcp-service-account: locust-master@ras-rm-performance-20220908.iam.gserviceaccount.com
+      iam.gke.io/gcp-service-account: ras-rm-k8s-services@ras-rm-performance-20220908.iam.gserviceaccount.com
     nodeSelector:
       iam.gke.io/gke-metadata-server-enabled: "true"
 
@@ -46,7 +47,7 @@ locust:
     strategy:
       type: RollingUpdate
     serviceAccountAnnotations:
-      iam.gke.io/gcp-service-account: locust-worker@ras-rm-performance-20220908.iam.gserviceaccount.com
+      iam.gke.io/gcp-service-account: ras-rm-k8s-services@ras-rm-performance-20220908.iam.gserviceaccount.com
     nodeSelector:
       iam.gke.io/gke-metadata-server-enabled: "true"
 

--- a/_infra/helm/locust/values.yaml
+++ b/_infra/helm/locust/values.yaml
@@ -33,7 +33,7 @@ locust:
     environment:
       LOCUST_USERS: 10
       LOCUST_SPAWN_RATE: 1
-      LOCUST_RUN_TIME: 35m
+      LOCUST_RUN_TIME: 10m
       LOCUST_ONLY_SUMMARY: true
       LOCUST_CSV: rasrm
     serviceAccountAnnotations:

--- a/_infra/helm/locust/values.yaml
+++ b/_infra/helm/locust/values.yaml
@@ -32,8 +32,8 @@ locust:
     environment:
       LOCUST_USERS: 10
       LOCUST_SPAWN_RATE: 1
-#      LOCUST_RUN_TIME: 10m
-      LOCUST_RUN_TIME: 35m
+      LOCUST_RUN_TIME: 14m
+#      LOCUST_RUN_TIME: 35m
       LOCUST_ONLY_SUMMARY: true
       LOCUST_CSV: rasrm
     serviceAccountAnnotations:

--- a/_infra/helm/locust/values.yaml
+++ b/_infra/helm/locust/values.yaml
@@ -32,8 +32,7 @@ locust:
     environment:
       LOCUST_USERS: 10
       LOCUST_SPAWN_RATE: 1
-      LOCUST_RUN_TIME: 14m
-#      LOCUST_RUN_TIME: 35m
+      LOCUST_RUN_TIME: 35m
       LOCUST_ONLY_SUMMARY: true
       LOCUST_CSV: rasrm
     serviceAccountAnnotations:


### PR DESCRIPTION
# What and why?
There is no way to change what service account the locust deployments unless we adopt the helm charts ourselves, which we don't want to do, but we can tell the service account to impersonate the main google service account, we use for our kubernetes services, by passing some annotations

The runtime also had to be changed because if the `on_test_stop` method is run after the tests are uninstalled, they are unable to authenticate with WIF to the bucket and can't upload the files. Therefore, the locust runtime is now lower than the helm sleep (which prevented double test runs before) and now there is a 1 minute sleep at the end of the tests to allow helm to uninstall the tests before a second run it started. 

# How to test?
Deploy performance using https://github.com/ONSdigital/ras-rm-terraform/pull/458
- comment out benchmark and destroy steps from the pipeline if you want to run multiple tests
Let the pipeline run and then check that the files are created in the bucket and the tests only start once (in the logs)
You can run the tests again if you want by triggering the locust step in concourse
# Jira
[RAS-1836](https://officefornationalstatistics.atlassian.net/browse/RAS-1836)